### PR TITLE
Nomination of @heisenberg as MapLibre Voting Member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -48,6 +48,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@HandyMenny](https://github.com/HandyMenny)
 
+[@heisenberg](https://github.com/heisenberg) (Atom Corp.) 
+
 [@hoeflehner](https://github.com/hoeflehner) (Maptoolkit)
 
 [@hy9be](https://github.com/hy9be) (AWS)


### PR DESCRIPTION
I would like to nominate @heisenberg to become a MapLibre Voting Member, because they contributed to MapLibre GL JS very good bug reports.

### I am a Voting Member

If you are a [MapLibre Voting Member](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md), you can vote on granting Voting Membership by approving this Pull Request to show your support for the person or by rejecting this Pull Request to indicate that you disagree with granting Voting Membership.

Voting is open until Thursday, Aug 22nd, 2024 at 17:00 CEST.

### I am nominated

If you have been nominated in this Pull Request to become a Voting Member, then you have two choices:


- You say YES, I want to be a Voting Member. In this case, please:
  - Approve this pull request.
  - We need your email for the online voting system OpaVote which is used for the Governing Board election. Send us your email address via the following form: LINK. 
- You say NO, I don't want to be a Voting Member. In this case, please
  - Comment below "Please close this pull request, I don't want to be a Voting Member".

### I would like to nominate someone

If you are a [MapLibre Voting Member](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md), you can nominate someone with this [Pull Request template](#).

### I would like to be nominated

If you are not a Voting Member but would like to become one, find someone who is on the [Voting Members list](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) and ask them if they can nominate you.

