### PR TITLE
Update VOTING_MEMBERS.md

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -210,6 +210,7 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@wipfli](https://github.com/wipfli)
 
+test
 [@xabbu42](https://github.com/xabbu42) (localsearch)
 
 [@ZeLonewolf](https://github.com/ZeLonewolf)


### PR DESCRIPTION
I would like to nominate @github_handle_here to become a MapLibre Voting Member.

## Motivation

<!-- Explain here why you believe @github_handle_here should be a Voting Member. -->

## Checklist

- [ ] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [ ] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [ ] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [ ] The nominee has shared their full name and contact e-mail with [Hubspot link].
- [ ] At the voting deadline[^1], more Voting Members have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md#process).

[^1]: Thursday, Aug 22nd, 2024 at 17:00 CEST
